### PR TITLE
Remove unused imports

### DIFF
--- a/os_windows.go
+++ b/os_windows.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"flag"
 	"fmt"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 )


### PR DESCRIPTION
Not sure why these are here, but they make "go get" fail on my Windows machine.
