### PR TITLE
[WIP] Use package path when qualifying types

### DIFF
--- a/suggest/candidate.go
+++ b/suggest/candidate.go
@@ -155,7 +155,7 @@ func (b *candidateCollector) qualify(pkg *types.Package) string {
 	if pkg == b.localpkg {
 		return ""
 	}
-	return pkg.Name()
+	return pkg.Path()
 }
 
 func (b *candidateCollector) appendObject(obj types.Object) {


### PR DESCRIPTION
Following discussion in #18 

I've marked this as `[WIP]` and am trying it locally to see how much 'noise' it generates (per your comment @mdempsky) via `vim-go`
