### PR TITLE
Use import name if set else package name when qualifying types

### DIFF
--- a/suggest/suggest.go
+++ b/suggest/suggest.go
@@ -26,7 +26,7 @@ func (c *Config) Suggest(filename string, data []byte, cursor int) ([]Candidate,
 		return nil, 0
 	}
 
-	fset, pos, pkg := c.analyzePackage(filename, data, cursor)
+	fset, pos, pkg, imports := c.analyzePackage(filename, data, cursor)
 	if pkg == nil {
 		return nil, 0
 	}
@@ -35,6 +35,7 @@ func (c *Config) Suggest(filename string, data []byte, cursor int) ([]Candidate,
 	ctx, expr, partial := deduceCursorContext(data, cursor)
 	b := candidateCollector{
 		localpkg: pkg,
+		imports:  imports,
 		partial:  partial,
 		filter:   objectFilters[partial],
 	}
@@ -75,7 +76,7 @@ func (c *Config) Suggest(filename string, data []byte, cursor int) ([]Candidate,
 	return res, len(partial)
 }
 
-func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*token.FileSet, token.Pos, *types.Package) {
+func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*token.FileSet, token.Pos, *types.Package, []*ast.ImportSpec) {
 	// If we're in trailing white space at the end of a scope,
 	// sometimes go/types doesn't recognize that variables should
 	// still be in scope there.
@@ -88,7 +89,7 @@ func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*toke
 	}
 	astPos := fileAST.Pos()
 	if astPos == 0 {
-		return nil, token.NoPos, nil
+		return nil, token.NoPos, nil, nil
 	}
 	pos := fset.File(astPos).Pos(cursor)
 
@@ -118,7 +119,7 @@ func (c *Config) analyzePackage(filename string, data []byte, cursor int) (*toke
 	}
 	pkg, _ := cfg.Check("", fset, files, nil)
 
-	return fset, pos, pkg
+	return fset, pos, pkg, fileAST.Imports
 }
 
 func (c *Config) fieldNameCandidates(typ types.Type, b *candidateCollector) {

--- a/suggest/testdata/test.0065/out.expected
+++ b/suggest/testdata/test.0065/out.expected
@@ -1,0 +1,26 @@
+Found 25 candidates:
+  func Errorf(format string, a ...interface{}) error
+  func Fprint(w banana.Writer, a ...interface{}) (n int, err error)
+  func Fprintf(w banana.Writer, format string, a ...interface{}) (n int, err error)
+  func Fprintln(w banana.Writer, a ...interface{}) (n int, err error)
+  func Fscan(r banana.Reader, a ...interface{}) (n int, err error)
+  func Fscanf(r banana.Reader, format string, a ...interface{}) (n int, err error)
+  func Fscanln(r banana.Reader, a ...interface{}) (n int, err error)
+  func Print(a ...interface{}) (n int, err error)
+  func Printf(format string, a ...interface{}) (n int, err error)
+  func Println(a ...interface{}) (n int, err error)
+  func Scan(a ...interface{}) (n int, err error)
+  func Scanf(format string, a ...interface{}) (n int, err error)
+  func Scanln(a ...interface{}) (n int, err error)
+  func Sprint(a ...interface{}) string
+  func Sprintf(format string, a ...interface{}) string
+  func Sprintln(a ...interface{}) string
+  func Sscan(str string, a ...interface{}) (n int, err error)
+  func Sscanf(str string, format string, a ...interface{}) (n int, err error)
+  func Sscanln(str string, a ...interface{}) (n int, err error)
+  type Formatter interface
+  type GoStringer interface
+  type ScanState interface
+  type Scanner interface
+  type State interface
+  type Stringer interface

--- a/suggest/testdata/test.0065/test.go.in
+++ b/suggest/testdata/test.0065/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+import (
+	"fmt"
+	banana "io"
+)
+
+var _ = fmt.@


### PR DESCRIPTION
Following discussion in #18; this is an alternative to #19 and is an implementation of option 3 from [this comment](https://github.com/mdempsky/gocode/issues/18#issuecomment-240154153)

Again, I've marked this as `[WIP]` and am trying it locally to see how things work out in `vim-go`
