### PR TITLE
Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: go
 
 go:
   - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - master

--- a/lookdot/lookdot_test.go
+++ b/lookdot/lookdot_test.go
@@ -117,7 +117,7 @@ func TestWalk(t *testing.T) {
 		}
 
 		if !lookdot.Walk(&tv, visitor) {
-			t.Error("Walk(%q) returned false", test.lhs)
+			t.Errorf("Walk(%q) returned false", test.lhs)
 			continue
 		}
 


### PR DESCRIPTION
This CL adds support for Go-1.10.
It also adds 1.9.x and 1.10.x to the list of Go versions to test with Travis-CI.