### PR TITLE
[WIP] server: initial cut of vgo-aware type loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+install:
+  - ./_scripts/install_vgo.sh
+
 go:
-  - 1.8.x
+  - 1.10.x
   - master

--- a/_scripts/install_vgo.sh
+++ b/_scripts/install_vgo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ "${CI:-}" == "true" ]
+then
+	go get -u golang.org/x/vgo
+	pushd $(go list -f "{{.Dir}}" golang.org/x/vgo) > /dev/null
+
+	git fetch -q https://go.googlesource.com/vgo refs/changes/55/105855/3 && git checkout -qf FETCH_HEAD
+	go install
+
+	popd > /dev/null
+fi
+
+# for the tests in ./vgo
+go get golang.org/x/net/html

--- a/gocode.go
+++ b/gocode.go
@@ -14,6 +14,7 @@ var (
 	g_sock      = flag.String("sock", defaultSocketType, "socket type (unix | tcp | none)")
 	g_addr      = flag.String("addr", "127.0.0.1:37373", "address for tcp socket")
 	g_debug     = flag.Bool("debug", false, "enable server-side debug mode")
+	g_vgo       = flag.Bool("vgo", false, "force vgo-mode; else auto-detect")
 )
 
 func getSocketPath() string {

--- a/lookdot/lookdot_test.go
+++ b/lookdot/lookdot_test.go
@@ -117,7 +117,7 @@ func TestWalk(t *testing.T) {
 		}
 
 		if !lookdot.Walk(&tv, visitor) {
-			t.Error("Walk(%q) returned false", test.lhs)
+			t.Errorf("Walk(%q) returned false", test.lhs)
 			continue
 		}
 

--- a/server.go
+++ b/server.go
@@ -8,11 +8,13 @@ import (
 	"net/rpc"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
 	"time"
 
 	"github.com/mdempsky/gocode/gbimporter"
 	"github.com/mdempsky/gocode/suggest"
+	"github.com/mdempsky/gocode/vgo"
 )
 
 func doServer() {
@@ -85,7 +87,7 @@ func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) 
 	}
 	now := time.Now()
 	cfg := suggest.Config{
-		Importer: gbimporter.New(&req.Context, req.Filename),
+		Importer: vgo.NewTestLoader(filepath.Dir(req.Filename)),
 	}
 	if *g_debug {
 		cfg.Logf = log.Printf

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/mdempsky/gocode/gbimporter"
@@ -99,8 +100,13 @@ func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) 
 		}
 	}
 
+	var vgoOutput *strings.Builder
+
 	if importer == nil {
-		importer = vgo.NewTestLoader(filepath.Dir(req.Filename))
+		v := vgo.NewTestLoader(filepath.Dir(req.Filename))
+		vgoOutput = new(strings.Builder)
+		v.Debug = vgoOutput
+		importer = v
 	}
 
 	if *g_debug {
@@ -126,6 +132,9 @@ func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) 
 	candidates, d := cfg.Suggest(req.Filename, req.Data, req.Cursor)
 	elapsed := time.Since(now)
 	if *g_debug {
+		if vgoOutput != nil {
+			log.Printf("vgo output was: \n%v\n", vgoOutput.String())
+		}
 		log.Printf("Elapsed duration: %v\n", elapsed)
 		log.Printf("Offset: %d\n", res.Len)
 		log.Printf("Number of candidates found: %d\n", len(candidates))

--- a/suggest/candidate.go
+++ b/suggest/candidate.go
@@ -2,6 +2,7 @@ package suggest
 
 import (
 	"fmt"
+	"go/ast"
 	"go/types"
 	"sort"
 	"strings"
@@ -77,6 +78,7 @@ type candidateCollector struct {
 	candidates []Candidate
 	exact      []types.Object
 	badcase    []types.Object
+	imports    []*ast.ImportSpec
 	localpkg   *types.Package
 	partial    string
 	filter     objectFilter
@@ -155,6 +157,26 @@ func (b *candidateCollector) qualify(pkg *types.Package) string {
 	if pkg == b.localpkg {
 		return ""
 	}
+
+	// the *types.Package we are asked to qualify might _not_ be imported
+	// by the file in which we are asking for candidates. Hence... we retain
+	// the default of pkg.Name() as the qualifier
+
+	for _, i := range b.imports {
+		// given the import spec has been correctly parsed (by virtue of
+		// its existence) we can safely byte-index the path value knowing
+		// that len("\"") == 1
+		iPath := i.Path.Value[1 : len(i.Path.Value)-1]
+
+		if iPath == pkg.Path() {
+			if i.Name != nil && i.Name.Name != "." {
+				return i.Name.Name
+			} else {
+				return pkg.Name()
+			}
+		}
+	}
+
 	return pkg.Name()
 }
 

--- a/suggest/testdata/test.0063/out.expected
+++ b/suggest/testdata/test.0063/out.expected
@@ -1,0 +1,26 @@
+Found 25 candidates:
+  func Errorf(format string, a ...interface{}) error
+  func Fprint(w banana.Writer, a ...interface{}) (n int, err error)
+  func Fprintf(w banana.Writer, format string, a ...interface{}) (n int, err error)
+  func Fprintln(w banana.Writer, a ...interface{}) (n int, err error)
+  func Fscan(r banana.Reader, a ...interface{}) (n int, err error)
+  func Fscanf(r banana.Reader, format string, a ...interface{}) (n int, err error)
+  func Fscanln(r banana.Reader, a ...interface{}) (n int, err error)
+  func Print(a ...interface{}) (n int, err error)
+  func Printf(format string, a ...interface{}) (n int, err error)
+  func Println(a ...interface{}) (n int, err error)
+  func Scan(a ...interface{}) (n int, err error)
+  func Scanf(format string, a ...interface{}) (n int, err error)
+  func Scanln(a ...interface{}) (n int, err error)
+  func Sprint(a ...interface{}) string
+  func Sprintf(format string, a ...interface{}) string
+  func Sprintln(a ...interface{}) string
+  func Sscan(str string, a ...interface{}) (n int, err error)
+  func Sscanf(str string, format string, a ...interface{}) (n int, err error)
+  func Sscanln(str string, a ...interface{}) (n int, err error)
+  type Formatter interface
+  type GoStringer interface
+  type ScanState interface
+  type Scanner interface
+  type State interface
+  type Stringer interface

--- a/suggest/testdata/test.0063/test.go.in
+++ b/suggest/testdata/test.0063/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+import (
+	"fmt"
+	banana "io"
+)
+
+var _ = fmt.@

--- a/vgo/loader.go
+++ b/vgo/loader.go
@@ -1,0 +1,157 @@
+// package vgo provides some utility types, functions etc to support vgo
+//
+// For now it is a copy of the WIP myitcv.io/vgo
+package vgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"go/importer"
+	"go/types"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Loader supports loading of vgo-build cached packages. NewLoader returns a
+// correctly initialised *Loader.  A Loader must not be copied once created.
+type Loader struct {
+	mu sync.Mutex
+
+	dir       string
+	compiler  string
+	resCache  map[string]map[string]*types.Package
+	importers map[string]types.ImporterFrom
+	test      bool
+}
+
+func NewLoader(dir string) *Loader {
+	res := &Loader{
+		dir:       dir,
+		compiler:  "gc",
+		resCache:  make(map[string]map[string]*types.Package),
+		importers: make(map[string]types.ImporterFrom),
+	}
+
+	return res
+}
+
+func NewTestLoader(dir string) *Loader {
+	res := NewLoader(dir)
+	res.test = true
+	return res
+}
+
+var _ types.ImporterFrom = new(Loader)
+
+func (l *Loader) Import(path string) (*types.Package, error) {
+	return nil, fmt.Errorf("did not expect this method to be used; we implement types.ImporterFrom")
+}
+
+func (l *Loader) ImportFrom(path, dir string, mode types.ImportMode) (*types.Package, error) {
+	if mode != 0 {
+		panic(fmt.Errorf("unknown types.ImportMode %v", mode))
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// TODO optimise mutex usage later... keep it simple for now
+	dirCache, ok := l.resCache[dir]
+	if ok {
+		if p, ok := dirCache[path]; ok {
+			return p, nil
+		}
+	} else {
+		// ensures dirCache is now set
+		dirCache = make(map[string]*types.Package)
+		l.resCache[dir] = dirCache
+	}
+
+	// res cache miss
+	imp, ok := l.importers[dir]
+	if !ok {
+		// we need to load the results for this dir and build an importer
+
+		// resolve the package found in dir
+		_, err := build.ImportDir(dir, 0)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve %v to a package: %v", dir, err)
+		}
+
+		// now run vgo depbuildlist with the import path
+		args := []string{"vgo", "deplist", "-build"}
+
+		if l.test {
+			args = append(args, "-test")
+		}
+
+		args = append(args, ".")
+
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = l.dir
+
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("unable to run %v: %v [%q]", strings.Join(cmd.Args, " "), err, string(out))
+		}
+
+		// parse the JSON
+
+		lookup := make(map[string]string)
+
+		dec := json.NewDecoder(bytes.NewBuffer(out))
+
+		for {
+			var d struct {
+				ImportPath  string
+				PackageFile string
+			}
+
+			if err := dec.Decode(&d); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				return nil, fmt.Errorf("failed to parse vgo output: %v\noutput was:\n%v", err, string(out))
+			}
+
+			lookup[d.ImportPath] = d.PackageFile
+		}
+
+		i := importer.For(l.compiler, func(path string) (io.ReadCloser, error) {
+			file, ok := lookup[path]
+			if !ok {
+				return nil, fmt.Errorf("failed to resolve import path %q", path)
+			}
+
+			f, err := os.Open(file)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open file %v: %v", file, err)
+			}
+
+			return f, nil
+		})
+
+		from, ok := i.(types.ImporterFrom)
+		if !ok {
+			return nil, fmt.Errorf("failed to get an importer that implements go/types.ImporterFrom; got %T", i)
+		}
+
+		imp = from
+		l.importers[dir] = imp
+	}
+
+	p, err := imp.ImportFrom(path, dir, mode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to import: %v", err)
+	}
+
+	dirCache[path] = p
+
+	return p, nil
+}

--- a/vgo/loader_test.go
+++ b/vgo/loader_test.go
@@ -1,0 +1,49 @@
+package vgo_test
+
+import (
+	"os"
+	"testing"
+
+	// import a non-standard library package for its side effects.
+	// vgo will then detect this
+	"github.com/mdempsky/gocode/vgo"
+	_ "golang.org/x/net/html"
+)
+
+func TestLoader(t *testing.T) {
+	// given the side-effect import above, we can now create a Loader
+	// to load "golang.org/x/net/html" in the context of the current
+	// directory
+
+	l := vgo.NewTestLoader(".")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", cwd)
+	}
+
+	cases := []string{
+		"golang.org/x/net/html",
+
+		// this is a dependency of x/net/html; hence an indirect
+		// test dependency of vgo_test
+		"golang.org/x/net/html/atom",
+	}
+
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			p, err := l.ImportFrom(c, cwd, 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if p == nil {
+				t.Fatal("expected response; got nil")
+			}
+
+			if v := p.Path(); v != c {
+				t.Fatalf("expected ImportPath %q; got %q", c, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE**

Requires `vgo` as of https://go-review.googlesource.com/c/vgo/+/105855

Note: this is based atop https://github.com/mdempsky/gocode/pull/23

The current diff for this PR can be see here:

https://github.com/myitcv/gocode/compare/import_name_qualify...myitcv:vgo_loader