### PR TITLE
suggest: fix panic handling completion in if condition

### DIFF
--- a/suggest/testdata/test.0064/out.expected
+++ b/suggest/testdata/test.0064/out.expected
@@ -1,0 +1,2 @@
+Found 1 candidates:
+  var fi int

--- a/suggest/testdata/test.0064/test.go.in
+++ b/suggest/testdata/test.0064/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+var fi int
+
+func main() {
+	if fi || f@ {
+	}
+}


### PR DESCRIPTION
In current master, test.0064 (part of this commit) causes a panic when
completion is requested. This is because the addition of a ';' causes a
syntax error;  the condition is now missing (it became an initialiser).

```
package p

var fi int

func main() {
        if fi || f@ {
        }
}
```

With thanks to @mvdan for his analysis.