### PR TITLE
add support for case-insensitive completion

### DIFF
--- a/suggest/candidate.go
+++ b/suggest/candidate.go
@@ -82,6 +82,7 @@ type candidateCollector struct {
 	partial    string
 	filter     objectFilter
 	builtin    bool
+	ignoreCase bool
 }
 
 func (b *candidateCollector) getCandidates() []Candidate {
@@ -182,7 +183,7 @@ func (b *candidateCollector) appendObject(obj types.Object) {
 		return
 	}
 
-	if b.filter != nil || strings.HasPrefix(obj.Name(), b.partial) {
+	if !b.ignoreCase && (b.filter != nil || strings.HasPrefix(obj.Name(), b.partial)) {
 		b.exact = append(b.exact, obj)
 	} else if strings.HasPrefix(strings.ToLower(obj.Name()), strings.ToLower(b.partial)) {
 		b.badcase = append(b.badcase, obj)

--- a/suggest/suggest.go
+++ b/suggest/suggest.go
@@ -15,9 +15,10 @@ import (
 )
 
 type Config struct {
-	Importer types.Importer
-	Logf     func(fmt string, args ...interface{})
-	Builtin  bool
+	Importer   types.Importer
+	Logf       func(fmt string, args ...interface{})
+	Builtin    bool
+	IgnoreCase bool
 }
 
 // Suggest returns a list of suggestion candidates and the length of
@@ -35,10 +36,11 @@ func (c *Config) Suggest(filename string, data []byte, cursor int) ([]Candidate,
 
 	ctx, expr, partial := deduceCursorContext(data, cursor)
 	b := candidateCollector{
-		localpkg: pkg,
-		partial:  partial,
-		filter:   objectFilters[partial],
-		builtin:  c.Builtin,
+		localpkg:   pkg,
+		partial:    partial,
+		filter:     objectFilters[partial],
+		builtin:    c.Builtin,
+		ignoreCase: c.IgnoreCase,
 	}
 
 	switch ctx {


### PR DESCRIPTION
given declarations

	func FunX()
	func funY()

with this enabled, completing `fun|` suggests both functions instead of just `funY`