### PR TITLE
Add support for case-insensitive matching

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,6 +129,7 @@ func cmdAutoComplete(c *rpc.Client) {
 	req.Context = gbimporter.PackContext(&build.Default)
 	req.Source = *g_source
 	req.Builtin = *g_builtin
+	req.IgnoreCase = *g_ignore_case
 
 	var res AutoCompleteReply
 	var err error

--- a/gocode.go
+++ b/gocode.go
@@ -8,14 +8,15 @@ import (
 )
 
 var (
-	g_is_server = flag.Bool("s", false, "run a server instead of a client")
-	g_format    = flag.String("f", "nice", "output format (vim | emacs | nice | csv | json)")
-	g_input     = flag.String("in", "", "use this file instead of stdin input")
-	g_sock      = flag.String("sock", defaultSocketType, "socket type (unix | tcp | none)")
-	g_addr      = flag.String("addr", "127.0.0.1:37373", "address for tcp socket")
-	g_debug     = flag.Bool("debug", false, "enable server-side debug mode")
-	g_source    = flag.Bool("source", false, "use source importer")
-	g_builtin   = flag.Bool("builtin", false, "propose builtin objects")
+	g_is_server   = flag.Bool("s", false, "run a server instead of a client")
+	g_format      = flag.String("f", "nice", "output format (vim | emacs | nice | csv | json)")
+	g_input       = flag.String("in", "", "use this file instead of stdin input")
+	g_sock        = flag.String("sock", defaultSocketType, "socket type (unix | tcp | none)")
+	g_addr        = flag.String("addr", "127.0.0.1:37373", "address for tcp socket")
+	g_debug       = flag.Bool("debug", false, "enable server-side debug mode")
+	g_source      = flag.Bool("source", false, "use source importer")
+	g_builtin     = flag.Bool("builtin", false, "propose builtin objects")
+	g_ignore_case = flag.Bool("ignore-case", false, "do case-insensitive matching")
 )
 
 func getSocketPath() string {

--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -81,6 +81,7 @@ type candidateCollector struct {
 	partial    string
 	filter     objectFilter
 	builtin    bool
+	ignoreCase bool
 }
 
 func (b *candidateCollector) getCandidates() []Candidate {
@@ -180,8 +181,7 @@ func (b *candidateCollector) appendObject(obj types.Object) {
 	if b.filter != nil && !b.filter(obj) {
 		return
 	}
-
-	if b.filter != nil || strings.HasPrefix(obj.Name(), b.partial) {
+	if !b.ignoreCase && (b.filter != nil || strings.HasPrefix(obj.Name(), b.partial)) {
 		b.exact = append(b.exact, obj)
 	} else if strings.HasPrefix(strings.ToLower(obj.Name()), strings.ToLower(b.partial)) {
 		b.badcase = append(b.badcase, obj)

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -15,9 +15,10 @@ import (
 )
 
 type Config struct {
-	Importer types.Importer
-	Logf     func(fmt string, args ...interface{})
-	Builtin  bool
+	Importer   types.Importer
+	Logf       func(fmt string, args ...interface{})
+	Builtin    bool
+	IgnoreCase bool
 }
 
 // Suggest returns a list of suggestion candidates and the length of
@@ -35,10 +36,11 @@ func (c *Config) Suggest(filename string, data []byte, cursor int) ([]Candidate,
 
 	ctx, expr, partial := deduceCursorContext(data, cursor)
 	b := candidateCollector{
-		localpkg: pkg,
-		partial:  partial,
-		filter:   objectFilters[partial],
-		builtin:  ctx != selectContext && c.Builtin,
+		localpkg:   pkg,
+		partial:    partial,
+		filter:     objectFilters[partial],
+		builtin:    ctx != selectContext && c.Builtin,
+		ignoreCase: c.IgnoreCase,
 	}
 
 	switch ctx {

--- a/internal/suggest/testdata/test.0066/config.json
+++ b/internal/suggest/testdata/test.0066/config.json
@@ -1,0 +1,1 @@
+{"IgnoreCase": false}

--- a/internal/suggest/testdata/test.0066/out.expected
+++ b/internal/suggest/testdata/test.0066/out.expected
@@ -1,0 +1,2 @@
+Found 1 candidates:
+  func FuncX()

--- a/internal/suggest/testdata/test.0066/test.go.in
+++ b/internal/suggest/testdata/test.0066/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+func FuncX() {}
+func funcY() {}
+
+func f() {
+	Fun@
+}

--- a/internal/suggest/testdata/test.0067/config.json
+++ b/internal/suggest/testdata/test.0067/config.json
@@ -1,0 +1,1 @@
+{"IgnoreCase": false}

--- a/internal/suggest/testdata/test.0067/out.expected
+++ b/internal/suggest/testdata/test.0067/out.expected
@@ -1,0 +1,2 @@
+Found 1 candidates:
+  func funcY()

--- a/internal/suggest/testdata/test.0067/test.go.in
+++ b/internal/suggest/testdata/test.0067/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+func FuncX() {}
+func funcY() {}
+
+func f() {
+	fun@
+}

--- a/internal/suggest/testdata/test.0068/config.json
+++ b/internal/suggest/testdata/test.0068/config.json
@@ -1,0 +1,1 @@
+{"IgnoreCase": true}

--- a/internal/suggest/testdata/test.0068/out.expected
+++ b/internal/suggest/testdata/test.0068/out.expected
@@ -1,0 +1,3 @@
+Found 2 candidates:
+  func FuncX()
+  func funcY()

--- a/internal/suggest/testdata/test.0068/test.go.in
+++ b/internal/suggest/testdata/test.0068/test.go.in
@@ -1,0 +1,8 @@
+package p
+
+func FuncX() {}
+func funcY() {}
+
+func f() {
+	fun@
+}

--- a/server.go
+++ b/server.go
@@ -52,12 +52,13 @@ type Server struct {
 }
 
 type AutoCompleteRequest struct {
-	Filename string
-	Data     []byte
-	Cursor   int
-	Context  gbimporter.PackedContext
-	Source   bool
-	Builtin  bool
+	Filename   string
+	Data       []byte
+	Cursor     int
+	Context    gbimporter.PackedContext
+	Source     bool
+	Builtin    bool
+	IgnoreCase bool
 }
 
 type AutoCompleteReply struct {
@@ -95,8 +96,9 @@ func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) 
 		underlying = importer.Default().(types.ImporterFrom)
 	}
 	cfg := suggest.Config{
-		Importer: gbimporter.New(&req.Context, req.Filename, underlying),
-		Builtin:  req.Builtin,
+		Importer:   gbimporter.New(&req.Context, req.Filename, underlying),
+		Builtin:    req.Builtin,
+		IgnoreCase: req.IgnoreCase,
 	}
 	if *g_debug {
 		cfg.Logf = log.Printf


### PR DESCRIPTION
Previously, completing `fmt.|` would suggest the builtins

This fixes #39