### PR TITLE
Added simple caching and set the default to use source importer

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,8 +14,8 @@ import (
 
 	"runtime/debug"
 
-	"github.com/mdempsky/gocode/internal/gbimporter"
-	"github.com/mdempsky/gocode/internal/suggest"
+	"github.com/phenixrizen/gocode/internal/gbimporter"
+	"github.com/phenixrizen/gocode/internal/suggest"
 )
 
 func doClient() {

--- a/gocode.go
+++ b/gocode.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 )
@@ -14,8 +16,10 @@ var (
 	g_sock      = flag.String("sock", defaultSocketType, "socket type (unix | tcp | none)")
 	g_addr      = flag.String("addr", "127.0.0.1:37373", "address for tcp socket")
 	g_debug     = flag.Bool("debug", false, "enable server-side debug mode")
-	g_source    = flag.Bool("source", false, "use source importer")
+	g_source    = flag.Bool("source", true, "use source importer")
 	g_builtin   = flag.Bool("builtin", false, "propose builtin objects")
+	g_profile   = flag.Bool("profile", false, "profile gocode")
+	g_cachettl  = flag.Int("cachettl", 60, "minutes for cache to live")
 )
 
 func getSocketPath() string {
@@ -44,9 +48,14 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
+	if *g_profile {
+		http.ListenAndServe("localhost:6060", nil)
+	}
+
 	if *g_is_server {
 		doServer()
 	} else {
 		doClient()
 	}
+
 }

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mdempsky/gocode/internal/lookdot"
+	"github.com/phenixrizen/gocode/internal/lookdot"
 )
 
 type Config struct {

--- a/server.go
+++ b/server.go
@@ -13,9 +13,11 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/mdempsky/gocode/internal/gbimporter"
-	"github.com/mdempsky/gocode/internal/suggest"
+	"github.com/phenixrizen/gocode/internal/gbimporter"
+	"github.com/phenixrizen/gocode/internal/suggest"
 )
+
+var cache = make(map[string]*types.Package)
 
 func doServer() {
 	addr := *g_addr
@@ -63,6 +65,7 @@ type AutoCompleteRequest struct {
 type AutoCompleteReply struct {
 	Candidates []suggest.Candidate
 	Len        int
+	Time       time.Time
 }
 
 func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) error {
@@ -95,7 +98,7 @@ func (s *Server) AutoComplete(req *AutoCompleteRequest, res *AutoCompleteReply) 
 		underlying = importer.Default().(types.ImporterFrom)
 	}
 	cfg := suggest.Config{
-		Importer: gbimporter.New(&req.Context, req.Filename, underlying),
+		Importer: gbimporter.New(&req.Context, req.Filename, underlying, cache, *g_cachettl),
 		Builtin:  req.Builtin,
 	}
 	if *g_debug {


### PR DESCRIPTION
Added a simple map to use as a cache for package lookups, added ttl on the packages cached by using go routine with a timer to expire the package in the map after 60 min.  This default ttl can be adjusted with the cachettl flag.  Also added the ability to profile gocode by passing the profile flag.