### PR TITLE
Do not panic when an embedded type is found

### DIFF
--- a/internal/lookdot/lookdot.go
+++ b/internal/lookdot/lookdot.go
@@ -74,7 +74,7 @@ func walk(typ0 types.Type, addable0, value bool, v Visitor) {
 			for _, t := range next {
 				nt := namedOf(t.typ)
 				if nt == nil {
-					panic("embedded struct field without name?")
+					continue
 				}
 				if !visited[nt] {
 					cur = append(cur, t)


### PR DESCRIPTION
This is causing lots of issues in Neovim/deoplete-go and breaks the autocompletion.

fixes #44