### PR TITLE
Add source option for company-go and go-autocomplete

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -72,6 +72,7 @@ symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
   (let ((code-buffer (current-buffer))
         (gocode-args (append company-go-gocode-args
                              (list "-f=csv-with-package"
+                                   "-source"
                                    "autocomplete"
                                    (or (buffer-file-name) "")
                                    (concat "c" (int-to-string (- (point) 1)))))))

--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -100,6 +100,7 @@
                                temp-buffer
                                nil
                                "-f=emacs"
+                               "-source"
                                "autocomplete"
                                (or (buffer-file-name) "")
                                (concat "c" (int-to-string (- (point) 1))))


### PR DESCRIPTION
Since the cache branch https://github.com/mdempsky/gocode/pull/71 has been merged and seems work well, it's helpful to add `-source` option as default for emacs users.