### PR TITLE
Link occur forcibly if exists

### DIFF
--- a/vim/symlink.sh
+++ b/vim/symlink.sh
@@ -3,5 +3,5 @@ cd "${0%/*}"
 ROOTDIR=`pwd`
 mkdir -p "$HOME/.vim/autoload"
 mkdir -p "$HOME/.vim/ftplugin/go"
-ln -s "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.vim/autoload/"
-ln -s "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.vim/ftplugin/go/"
+ln -sf "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.vim/autoload/"
+ln -sf "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.vim/ftplugin/go/"


### PR DESCRIPTION
If the target file already exists, `:PlugInstall` command occurs error.