### PR TITLE
gbimporter: handle GOROOT/GOPATH with trailing slash

### DIFF
--- a/internal/gbimporter/gbimporter.go
+++ b/internal/gbimporter/gbimporter.go
@@ -41,11 +41,15 @@ func New(ctx *cache.PackedContext, filename string, underlying types.Importer, l
 
 		gbroot := filepath.FromSlash(slashed[:i])
 		gbvendor := filepath.Join(gbroot, "vendor")
-		if cache.SamePath(gbroot, imp.ctx.GOROOT) {
+
+		// If there is a slash at end of GOROOT or GOPATH, we'll
+		// consider this file is inside a gb project wrongly.
+		if cache.SamePath(gbroot, strings.TrimRight(imp.ctx.GOROOT, "\\/")) {
 			goto Found
 		}
 		for _, path := range paths {
-			if cache.SamePath(path, gbroot) || cache.SamePath(path, gbvendor) {
+			pathNoLastSlash := strings.TrimRight(path, "\\/")
+			if cache.SamePath(pathNoLastSlash, gbroot) || cache.SamePath(pathNoLastSlash, gbvendor) {
 				goto Found
 			}
 		}


### PR DESCRIPTION
Today, I configure "GOPATH" to "/xxx/", that is, with a trailing backslash, then YouCompleteMe fail to give completion because gocode consider my project as a gb project.

Hope this PR will save a whole day for guys making the same mistake.
