### PR TITLE
Add the receiver to method completions

### DIFF
--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Candidate struct {
-	Class   string `json:"class"`
-	PkgPath string `json:"package"`
-	Name    string `json:"name"`
-	Type    string `json:"type"`
+	Class    string `json:"class"`
+	PkgPath  string `json:"package"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Receiver string `json:"receiver"`
 }
 
 func (c Candidate) Suggestion() string {
@@ -129,11 +130,19 @@ func (b *candidateCollector) asCandidate(obj types.Object) Candidate {
 		path = pkg.Path()
 	}
 
+	receiver := ""
+	if sig, ok := typ.(*types.Signature); ok {
+		if receiverVar := sig.Recv(); receiverVar != nil {
+			receiver = types.TypeString(receiverVar.Type(), func(*types.Package) string { return "" })
+		}
+	}
+
 	return Candidate{
-		Class:   objClass,
-		PkgPath: path,
-		Name:    obj.Name(),
-		Type:    typStr,
+		Class:    objClass,
+		PkgPath:  path,
+		Name:     obj.Name(),
+		Type:     typStr,
+		Receiver: receiver,
 	}
 }
 

--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -131,12 +131,10 @@ func (b *candidateCollector) asCandidate(obj types.Object) Candidate {
 	}
 
 	var receiver string
-	if sig, ok := typ.(*types.Signature); ok {
-		if sig.Recv() != nil {
-			receiver = types.TypeString(sig.Recv().Type(), func(*types.Package) string {
-				return ""
-			})
-		}
+	if sig, ok := typ.(*types.Signature); ok && sig.Recv() != nil {
+		receiver = types.TypeString(sig.Recv().Type(), func(*types.Package) string {
+			return ""
+		})
 	}
 
 	return Candidate{

--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -13,7 +13,7 @@ type Candidate struct {
 	PkgPath  string `json:"package"`
 	Name     string `json:"name"`
 	Type     string `json:"type"`
-	Receiver string `json:"receiver"`
+	Receiver string `json:"receiver,omitempty"`
 }
 
 func (c Candidate) Suggestion() string {

--- a/internal/suggest/candidate.go
+++ b/internal/suggest/candidate.go
@@ -130,10 +130,12 @@ func (b *candidateCollector) asCandidate(obj types.Object) Candidate {
 		path = pkg.Path()
 	}
 
-	receiver := ""
+	var receiver string
 	if sig, ok := typ.(*types.Signature); ok {
-		if receiverVar := sig.Recv(); receiverVar != nil {
-			receiver = types.TypeString(receiverVar.Type(), func(*types.Package) string { return "" })
+		if sig.Recv() != nil {
+			receiver = types.TypeString(sig.Recv().Type(), func(*types.Package) string {
+				return ""
+			})
 		}
 	}
 


### PR DESCRIPTION
Fixes #9 

P.S. I think the type for method expressions already includes the first receiver argument without any further changes to our code. At least it did when I tried it.

This can be used to fix https://github.com/Microsoft/vscode-go/issues/2107