### PR TITLE
Fix Emacs Company Mode for External Packages

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -76,7 +76,8 @@ symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
 (defun company-go--invoke-autocomplete ()
   (let ((code-buffer (current-buffer))
         (gocode-args (append company-go-gocode-args
-                             (list "-f=csv-with-package"
+                             (list "-source"
+                                   "-f=csv"
                                    "autocomplete"
                                    (or (buffer-file-name) "")
                                    (concat "c" (int-to-string (- (point) 1)))))))


### PR DESCRIPTION
Apply changes in https://github.com/mdempsky/gocode/issues/79 to emacs company-go mode so auto-completion of non-local packages works. Mirrors changes in https://github.com/nsf/gocode/pull/530. This way completion works if you just checkout this repo and point emacs to this instance of go-code.