### PR TITLE
Implemented S-Expression formatter

### DIFF
--- a/docs/autocomplete_formats.md
+++ b/docs/autocomplete_formats.md
@@ -96,6 +96,12 @@ client_set,,func(cli *rpc.Client, Arg0, Arg1 string) string
 client_status,,func(cli *rpc.Client, Arg0 int) string
 ```
 
+## sexp ##
+Output in form of S-Expressions. Example:
+```
+((func "client_auto_complete" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int, Arg3 gocode_env) (c []candidate, d int)" "gocode")(func "client_close" "func(cli *rpc.Client, Arg0 int) int" "gocode")(func "client_cursor_type_pkg" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int) (typ, pkg string)" "gocode")(func "client_drop_cache" "func(cli *rpc.Client, Arg0 int) int" "gocode")(func "client_highlight" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 gocode_env) (c []highlight_range, d int)" "gocode")(func "client_set" "func(cli *rpc.Client, Arg0, Arg1 string) string" "gocode")(func "client_status" "func(cli *rpc.Client, Arg0 int) string" "gocode"))
+```
+
 ## csv ##
 Comma-separated values format which has small size. Example:
 ```csv

--- a/gocode.go
+++ b/gocode.go
@@ -10,7 +10,7 @@ import (
 var (
 	g_is_server           = flag.Bool("s", false, "run a server instead of a client")
 	g_cache               = flag.Bool("cache", false, "use the cache importer")
-	g_format              = flag.String("f", "nice", "output format (vim | emacs | nice | csv | json)")
+	g_format              = flag.String("f", "nice", "output format (vim | emacs | sexp | nice | csv | json)")
 	g_input               = flag.String("in", "", "use this file instead of stdin input")
 	g_sock                = flag.String("sock", defaultSocketType, "socket type (unix | tcp | none)")
 	g_addr                = flag.String("addr", "127.0.0.1:37373", "address for tcp socket")

--- a/internal/suggest/formatters.go
+++ b/internal/suggest/formatters.go
@@ -12,6 +12,7 @@ var Formatters = map[string]Formatter{
 	"csv":              csvFormat,
 	"csv-with-package": csvFormat,
 	"emacs":            emacsFormat,
+	"sexp":             sexpFormat,
 	"godit":            goditFormat,
 	"json":             jsonFormat,
 	"nice":             NiceFormat,
@@ -69,6 +70,14 @@ func emacsFormat(w io.Writer, candidates []Candidate, num int) {
 		}
 		fmt.Fprintf(w, "%s,,%s\n", c.Name, hint)
 	}
+}
+
+func sexpFormat(w io.Writer, candidates []Candidate, num int) {
+	fmt.Fprint(w, "(")
+	for _, c := range candidates {
+		fmt.Fprintf(w, "(%s \"%s\" \"%s\" \"%s\")", c.Class, c.Name, c.Type, c.PkgPath)
+	}
+	fmt.Fprint(w, ")")
 }
 
 func csvFormat(w io.Writer, candidates []Candidate, num int) {

--- a/internal/suggest/formatters_test.go
+++ b/internal/suggest/formatters_test.go
@@ -81,7 +81,8 @@ client_drop_cache,,func(cli *rpc.Client, Arg0 int) int
 client_highlight,,func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 gocode_env) (c []highlight_range, d int)
 client_set,,func(cli *rpc.Client, Arg0, Arg1 string) string
 client_status,,func(cli *rpc.Client, Arg0 int) string
-`[1:]},
+`[1:]}, {"sexp", `
+((func "client_auto_complete" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int, Arg3 gocode_env) (c []candidate, d int)" "gocode")(func "client_close" "func(cli *rpc.Client, Arg0 int) int" "gocode")(func "client_cursor_type_pkg" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int) (typ, pkg string)" "gocode")(func "client_drop_cache" "func(cli *rpc.Client, Arg0 int) int" "gocode")(func "client_highlight" "func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 gocode_env) (c []highlight_range, d int)" "gocode")(func "client_set" "func(cli *rpc.Client, Arg0, Arg1 string) string" "gocode")(func "client_status" "func(cli *rpc.Client, Arg0 int) string" "gocode"))`[1:]},
 		{"csv", `
 func,,client_auto_complete,,func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int, Arg3 gocode_env) (c []candidate, d int),,gocode
 func,,client_close,,func(cli *rpc.Client, Arg0 int) int,,gocode


### PR DESCRIPTION
I'm currently implementing an alternative completion package for Emacs, and when I looked at the output formats, I thought `emacs` would be the best, but I don't really understand how 

    client_auto_complete,,func(cli *rpc.Client, Arg0 []byte, Arg1 string, Arg2 int, Arg3 gocode_env) (c []candidate, d int)

is better or worse for emacs than anything else (but maybe I'm just missing something). So my suggestion is to add an `sexp` (S-Expression) format, next to `emacs` -- for backwards compatibility -- to make reading easier (just use [read](https://www.gnu.org/software/emacs/manual/html_node/elisp/Input-Functions.html#index-read)). 

I've added some tests and the documentation I saw being necessary, but in case I missed something, please do tell me, and I'll try my best to fix it. 