### PR TITLE
Start server with -cache when client sets -fallback-to-source

### DIFF
--- a/client.go
+++ b/client.go
@@ -87,7 +87,7 @@ func doClient() {
 func tryStartServer() error {
 	path := get_executable_filename()
 	args := []string{os.Args[0], "-s", "-sock", *g_sock, "-addr", *g_addr}
-	if *g_cache {
+	if *g_cache || *g_fallback_to_source {
 		args = append(args, "-cache")
 	}
 	cwd, _ := os.Getwd()


### PR DESCRIPTION
`-fallback-to-source` requires `-cache` on the server-side, but the auto-started server did not check for this condition, making this flag useless for any client that did not start its own server.

Example:
```bash
$ # using 7fb65232883f19a8305706b4b4ff32916ffbcaf5
$ pkill gocode
$ gocode -fallback-to-source -in main.go autocomplete 67
Nothing to complete.
$ pkill gocode
$ # using this patch
$ gocode -fallback-to-source -in main.go autocomplete 67
Found 28 candidates:
  func CopyStandardLogTo(name string)
  func Error(args ...interface{})
  func ErrorDepth(depth int, args ...interface{})
  func Errorf(format string, args ...interface{})
  func Errorln(args ...interface{})
  func Exit(args ...interface{})
  func ExitDepth(depth int, args ...interface{})
  func Exitf(format string, args ...interface{})
  func Exitln(args ...interface{})
  func Fatal(args ...interface{})
  func FatalDepth(depth int, args ...interface{})
  func Fatalf(format string, args ...interface{})
  func Fatalln(args ...interface{})
  func Flush()
  func Info(args ...interface{})
  func InfoDepth(depth int, args ...interface{})
  func Infof(format string, args ...interface{})
  func Infoln(args ...interface{})
  func V(level glog.Level) glog.Verbose
  func Warning(args ...interface{})
  func WarningDepth(depth int, args ...interface{})
  func Warningf(format string, args ...interface{})
  func Warningln(args ...interface{})
  type Level int32
  type OutputStats struct
  type Verbose bool
  var MaxSize uint64
  var Stats struct
```

Likely fixes https://github.com/mdempsky/gocode/issues/84 (haven't tested)